### PR TITLE
Ask the IG publisher to compare with IPA

### DIFF
--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -197,6 +197,6 @@ parameters:
   apply-jurisdiction: true
   apply-publisher: true
   apply-version: true
-
+  ipa-comparison: "{last}" # "{current}" | "{last}"
 
 


### PR DESCRIPTION
This creates a new line in the QA report created by the IG publisher, with a link to a separate page that lists any mismatches between the implementation guides.

Fixes #42.